### PR TITLE
fix: content_url for story submissions

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -753,7 +753,7 @@ export class FurAffinityClient {
               result = typeFinderRoot.attr("data-fullview-src");
             } else if (type === "story") {
               const slink = element.find(
-                "#submission-content a[href*='/stories/']"
+                ".submission-content a[href*='/stories/']"
               );
               result = slink.attr("href");
             } else if (type === "music") {


### PR DESCRIPTION
On the modern UI, the download link for story-type submissions is contained by `.submission-content`, not `#submission-content`.

Example:

<https://www.furaffinity.net/view/57733647/> should have a `content_url` of
<https://d.furaffinity.net/art/jetfire/stories/1723508264/1723508264.jetfire_stormy_skies.pdf>.